### PR TITLE
docs: update framework versions and project structure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -335,7 +335,7 @@ src/main/java/bunny/boardhole/
 ├── auth/                                 # 인증 도메인
 │   └── [동일한 패키지 구조]
 │
-├── admin/                                # 관리 도메인
+├── email/                                # 이메일 도메인
 │   └── [동일한 패키지 구조]
 │
 └── shared/                               # 공유 모듈 (이전 common)
@@ -375,19 +375,18 @@ src/main/java/bunny/boardhole/
 graph TD
     A[board] --> B[user]
     C[auth] --> B[user]
-    D[admin] --> B[user]
-    D[admin] --> A[board]
-    
-    A --> E[common]
-    B --> E[common]
-    C --> E[common]
-    D --> E[common]
+    D[email] --> B[user]
+
+    A --> E[shared]
+    B --> E[shared]
+    C --> E[shared]
+    D --> E[shared]
 ```
 
 - `board` 도메인은 `user` 도메인에 의존 (작성자 정보)
 - `auth` 도메인은 `user` 도메인에 의존 (인증 대상)
-- `admin` 도메인은 `user`, `board` 도메인에 의존 (관리 대상)
-- 모든 도메인은 `common` 모듈 사용
+- `email` 도메인은 `user` 도메인에 의존 (이메일 인증)
+- 모든 도메인은 `shared` 모듈 사용
 
 ### Layer Dependencies
 

--- a/README.md
+++ b/README.md
@@ -48,43 +48,51 @@
 | 기술 | 버전 | 용도 |
 |------|------|------|
 | **Java** | 21 | 기본 언어 |
-| **Spring Boot** | 3.5.4 | 프레임워크 |
+| **Spring Boot** | 3.5.5 | 프레임워크 |
 | **Spring Web** | - | MVC 패턴 |
 | **MySQL** | 8.4 | 운영/로컬 DB (Compose)
 | **Testcontainers** | 1.20+ | 테스트용 컨테이너 DB |
 | **Lombok** | - | 코드 간소화 |
-| **SpringDoc OpenAPI** | 2.3.0 | API 문서화 |
+| **SpringDoc OpenAPI** | 2.8.11 | API 문서화 |
 | **Gradle** | 8.14.3 | 빌드 도구 |
 
 ## 프로젝트 구조
 
 ```
-src/main/java/bunny/boardhole/
-├── BoardHoleApplication.java           # Spring Boot 메인 클래스
-├── controller/                         # Controller 레이어
-│   ├── UserController.java             #   - 사용자 CRUD API
-│   ├── BoardController.java            #   - 게시판 CRUD API
-│   └── AuthController.java             #   - 로그인 API
-├── application/                        # CQRS(Application) 계층
-│   ├── command/                        #   - 쓰기용 서비스/커맨드/핸들러
-│   │   ├── BoardCommandService.java
-│   │   ├── UserCommandService.java
-│   │   └── ...Commands/Handlers
-│   ├── query/                          #   - 읽기용 서비스/쿼리
-│   │   ├── BoardQueryService.java
-│   │   ├── UserQueryService.java
-│   │   └── GetBoardQuery.java
-│   ├── result/                         #   - 서비스 반환 모델(Result)
-│   │   ├── BoardResult.java
-│   │   └── UserResult.java
-│   └── event/                          #   - 이벤트/리스너
-│       ├── ViewedEvent.java
-│       └── ViewedEventListener.java
-├── service/                            # 도메인 보조 서비스 (비동기/공통)
-│   └── ViewCountService.java
-├── repository/                         # Spring Data JPA Repositories (엔티티 반환)
-├── domain/                             # 엔티티/도메인 모델
-└── controller/                         # REST 컨트롤러(요청/응답 모델)
+src/main/
+├── java/bunny/boardhole/
+│   ├── BoardHoleApplication.java          # Spring Boot 메인 클래스
+│   ├── auth/                              # 인증/인가 도메인
+│   │   ├── application/                   #   - command/query/result
+│   │   ├── domain/
+│   │   ├── infrastructure/
+│   │   └── presentation/                  #   - controller/dto/mapper
+│   ├── board/                             # 게시판 도메인
+│   │   ├── application/                   #   - command/event/mapper/query/result
+│   │   ├── domain/                        #   - 엔티티 및 검증
+│   │   ├── infrastructure/
+│   │   └── presentation/
+│   ├── email/                             # 이메일 모듈
+│   │   ├── application/
+│   │   ├── domain/
+│   │   ├── infrastructure/
+│   │   └── presentation/
+│   ├── shared/                            # 공통 설정/유틸
+│   │   ├── bootstrap/
+│   │   ├── config/                        #   - cors/log/properties
+│   │   ├── constants/
+│   │   ├── exception/
+│   │   ├── mapstruct/
+│   │   ├── security/
+│   │   └── util/
+│   └── user/                              # 사용자 도메인
+│       ├── application/                   #   - command/mapper/query/result
+│       ├── domain/                        #   - 엔티티 및 검증
+│       ├── infrastructure/
+│       └── presentation/
+└── resources/
+    ├── static/assets/js/
+    └── templates/email/
 ```
 
 ### 레이어드 아키텍처

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,7 @@ Board-Hole은 교육용 프로젝트이지만, 실제 환경에서 사용할 수
 - **🔍 Input Validation**: Bean Validation과 custom validators
 - **🚫 CORS Protection**: Cross-Origin Resource Sharing 설정
 - **🔒 Password Security**: 안전한 비밀번호 저장 (BCrypt)
+- **📧 Email Verification Enforcement**: 이메일 미인증 사용자 차단 및 재발송 링크 제공
 
 ## 🔑 Authentication & Authorization
 
@@ -78,8 +79,11 @@ public class SecurityConfig {
                 .maximumSessions(1)  // 동시 세션 제한
                 .maxSessionsPreventsLogin(false))  // 기존 세션 만료 허용
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/auth/**").permitAll()  // 인증 엔드포인트 공개
-                .requestMatchers(HttpMethod.GET, "/api/boards/**").permitAll()  // 조회 공개
+                .requestMatchers("/api/auth/signup", "/api/auth/login").permitAll()
+                .requestMatchers("/api/auth/verify-email", "/api/auth/resend-verification").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/users/{id}/email/verify").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/users/{id}/email/resend").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/boards", "/api/boards/**").permitAll()
                 .anyRequest().authenticated())  // 나머지는 인증 필요
             .securityContext(securityContext -> securityContext
                 .securityContextRepository(httpSessionSecurityContextRepository()))
@@ -98,6 +102,8 @@ public class SecurityConfig {
 - `GET /api/boards/{id}` - 게시글 상세 조회
 - `POST /api/auth/login` - 로그인
 - `POST /api/users` - 사용자 회원가입
+- `GET /api/users/{id}/email/verify` - 이메일 인증 확인
+- `POST /api/users/{id}/email/resend` - 인증 이메일 재발송
 
 #### Authenticated Access (인증 필요)
 - `POST /api/boards` - 게시글 작성

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,7 @@ Board-Hole REST API 완전 명세서
 - [Boards API](#boards-api)
 - [Users API](#users-api)
 - [Auth API](#auth-api)
+- [Email API](#email-api)
 - [Admin API](#admin-api)
 - [Error Handling](#error-handling)
 - [Examples](#examples)
@@ -424,6 +425,26 @@ Cookie: JSESSIONID=...
   "roles": ["ADMIN"],
   "lastLogin": "2024-12-22T16:00:00"
 }
+```
+
+## ✉️ Email API
+
+이메일 인증 관련 엔드포인트
+
+### Verify Email
+
+사용자 이메일을 토큰으로 검증합니다.
+
+```http
+GET /api/users/{id}/email/verify?token=abc123
+```
+
+### Resend Verification Email
+
+미인증 사용자에게 인증 이메일을 다시 보냅니다.
+
+```http
+POST /api/users/{id}/email/resend
 ```
 
 ## 👑 Admin API

--- a/src/main/java/bunny/boardhole/shared/config/SecurityConfig.java
+++ b/src/main/java/bunny/boardhole/shared/config/SecurityConfig.java
@@ -87,6 +87,8 @@ public class SecurityConfig {
                         // Public API endpoints - explicit permit only
                         .requestMatchers(ApiPaths.AUTH + ApiPaths.AUTH_SIGNUP, ApiPaths.AUTH + ApiPaths.AUTH_LOGIN, ApiPaths.AUTH + ApiPaths.AUTH_PUBLIC_ACCESS).permitAll()
                         .requestMatchers(ApiPaths.AUTH + "/verify-email", ApiPaths.AUTH + "/resend-verification").permitAll()
+                        .requestMatchers(HttpMethod.GET, ApiPaths.USERS + "/{id}/email/verify").permitAll()
+                        .requestMatchers(HttpMethod.POST, ApiPaths.USERS + "/{id}/email/resend").permitAll()
                         .requestMatchers(HttpMethod.GET, ApiPaths.BOARDS, ApiPaths.BOARDS + "/**").permitAll()
                         // All other requests require authentication by default
                         .anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- align documented Spring Boot and SpringDoc versions with build config
- replace project structure snippet with current module layout
- remove duplicate controller entry from project structure section
- add email module to architecture and document email verification API
- expose email verification endpoints publicly and describe them in the security policy

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb05c628832da5b64b9075b7e5b2