### PR TITLE
feat: enable profile image upload from my page

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -80,6 +80,8 @@ log.user.password.change.failed=패스워드 변경 실패 - 현재 패스워드
 # ========================================
 success.email-verification.completed=이메일 인증이 완료되었습니다
 success.email-verification.resent=인증 이메일이 재발송되었습니다
+success.user.profile-image.updated=프로필 이미지가 업데이트되었습니다
+success.user.profile-image.removed=프로필 이미지가 삭제되었습니다
 # ========================================
 # 유효성 검증 - 게시판 관련
 # ========================================

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -100,6 +100,8 @@ log.user.password.change.failed=Password change failed - current password mismat
 # ========================================
 success.email-verification.completed=Email verification completed
 success.email-verification.resent=Verification email resent
+success.user.profile-image.updated=Profile image updated successfully
+success.user.profile-image.removed=Profile image removed successfully
 error.conflict=Conflict occurred
 error.access.denied=You do not have permission to access this page
 error.auth.required=Login is required to access this page

--- a/src/main/resources/messages_ko.properties
+++ b/src/main/resources/messages_ko.properties
@@ -100,6 +100,8 @@ log.user.password.change.failed=패스워드 변경 실패 - 현재 패스워드
 # ========================================
 success.email-verification.completed=이메일 인증이 완료되었습니다
 success.email-verification.resent=인증 이메일이 재발송되었습니다
+success.user.profile-image.updated=프로필 이미지가 업데이트되었습니다
+success.user.profile-image.removed=프로필 이미지가 삭제되었습니다
 error.conflict=데이터 충돌이 발생했습니다
 error.access.denied=이 페이지에 접근할 권한이 없습니다
 error.auth.required=로그인이 필요한 페이지입니다

--- a/src/main/resources/templates/boards/detail.html
+++ b/src/main/resources/templates/boards/detail.html
@@ -121,7 +121,8 @@
 
                         <footer class="mt-10 flex items-center justify-end gap-4 border-t border-slate-200 pt-6">
                             <div sec:authorize="hasPermission(#vars.board.id, 'BOARD', 'WRITE')"
-                                 class="flex items-center gap-3">
+                                 class="flex items-center gap-3"
+                                 data-testid="manage-menu">
                                 <a th:href="@{/boards/{id}/edit(id=${board.id})}" href="./edit.html"
                                    class="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-700">
                                     수정하기

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -13,7 +13,7 @@
             <div class="tip-wrapper relative flex w-full group/tip">
                 <a class="tip-anchor flex h-20 w-full items-center justify-center cursor-pointer transition-all duration-150 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:color-mix(in_srgb,white_60%,#2563eb)] [anchor-name:--tip-profile]"
                    th:href="@{/users/me}" href="/users/me"
-                   aria-label="Profile" aria-describedby="layout-tip-profile">
+                   aria-label="Profile" aria-describedby="index-tip-profile">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                          class="lucide lucide-user-round-icon lucide-user-round">
@@ -25,12 +25,13 @@
                      class="tip-tooltip pointer-events-none absolute z-10 overflow-hidden rounded-xl bg-slate-900/90 px-3 py-2 text-xs font-medium text-white opacity-0 invisible delay-150 [transition-property:opacity,visibility] duration-150 [transition-behavior:allow-discrete] [position-anchor:--tip-profile] [top:anchor(center)] [left:calc(anchor(end)+12px)] [translate:0_-50%] whitespace-nowrap text-left leading-5 text-ellipsis [max-inline-size:clamp(8rem,30vw,12rem)] group-hover/tip:delay-0 group-hover/tip:opacity-100 group-hover/tip:visible group-focus-visible/tip:delay-0 group-focus-visible/tip:opacity-100 group-focus-visible/tip:visible">
                     Profile
                 </div>
+                <div id="index-tip-profile" role="tooltip" class="sr-only">Profile</div>
             </div>
 
             <div class="tip-wrapper relative flex w-full group/tip">
                 <button popovertarget="searchPopover" popovertargetaction="toggle"
                         class="tip-anchor flex h-20 w-full items-center justify-center cursor-pointer text-slate-400 transition-all duration-150 hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:color-mix(in_srgb,white_60%,#2563eb)] [anchor-name:--tip-search]"
-                        aria-label="검색 열기" aria-describedby="layout-tip-search">
+                        aria-label="검색 열기" aria-describedby="index-tip-search">
                     <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5" fill="none"
                          stroke="currentColor" stroke-width="1.75" stroke-linecap="round"
                          stroke-linejoin="round">
@@ -42,6 +43,7 @@
                      class="tip-tooltip pointer-events-none absolute z-10 overflow-hidden rounded-xl bg-slate-900/90 px-3 py-2 text-xs font-medium text-white opacity-0 invisible delay-150 [transition-property:opacity,visibility] duration-150 [transition-behavior:allow-discrete] [position-anchor:--tip-search] [top:anchor(center)] [left:calc(anchor(end)+12px)] [translate:0_-50%] whitespace-nowrap text-left leading-5 text-ellipsis [max-inline-size:clamp(8rem,30vw,12rem)] group-hover/tip:delay-0 group-hover/tip:opacity-100 group-hover/tip:visible group-focus-visible/tip:delay-0 group-focus-visible/tip:opacity-100 group-focus-visible/tip:visible">
                     검색
                 </div>
+                <div id="index-tip-search" role="tooltip" class="sr-only">검색</div>
             </div>
         </div>
 
@@ -51,7 +53,7 @@
                    th:href="@{/boards}" href="/boards"
                    th:classappend="${#strings.startsWith(requestUri, '/boards')} ? ' bg-slate-900 text-white hover:bg-slate-900 hover:text-white' : ''"
                    th:attr="aria-current=${#strings.startsWith(requestUri, '/boards')} ? 'page' : null"
-                   aria-label="게시판" aria-describedby="layout-tip-board">
+                   aria-label="게시판" aria-describedby="index-tip-board">
                     <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor"
                          stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="4" y="3" width="14" height="18" rx="2"/>
@@ -64,6 +66,7 @@
                      class="tip-tooltip pointer-events-none absolute z-10 overflow-hidden rounded-xl bg-slate-900/90 px-3 py-2 text-xs font-medium text-white opacity-0 invisible delay-150 [transition-property:opacity,visibility] duration-150 [transition-behavior:allow-discrete] [position-anchor:--tip-board] [top:anchor(center)] [left:calc(anchor(end)+12px)] [translate:0_-50%] whitespace-nowrap text-left leading-5 text-ellipsis [max-inline-size:clamp(8rem,30vw,12rem)] group-hover/tip:delay-0 group-hover/tip:opacity-100 group-hover/tip:visible group-focus-visible/tip:delay-0 group-focus-visible/tip:opacity-100 group-focus-visible/tip:visible">
                     게시판
                 </div>
+                <div id="index-tip-board" role="tooltip" class="sr-only">게시판</div>
             </div>
 
             <div class="tip-wrapper relative flex w-full group/tip"

--- a/src/main/resources/templates/users/detail.html
+++ b/src/main/resources/templates/users/detail.html
@@ -26,7 +26,7 @@
                         <aside class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
                             <h2 class="text-lg font-semibold text-slate-800">프로필 이미지</h2>
                             <p class="mt-2 text-sm leading-6 text-slate-500">업로드된 이미지는 전용 API를 통해 불러와 브라우저가 병렬로 다운로드합니다.</p>
-                            <div class="mt-6 flex flex-col items-center gap-4"
+                            <div class="mt-6 flex w-full flex-col items-center gap-4"
                                  th:with="displayName=${(user.name != null and !#strings.isEmpty(user.name)) ? user.name : user.username}">
                                 <figure class="relative flex h-48 w-48 items-center justify-center overflow-hidden rounded-full bg-slate-100 shadow-inner ring-1 ring-inset ring-slate-200">
                                     <img th:if="${user.hasProfileImage}"
@@ -39,7 +39,7 @@
                                           th:text="${#strings.substring(displayName, 0, 1)}"
                                           class="text-5xl font-semibold text-slate-400"></span>
                                 </figure>
-                                <div class="text-center text-sm text-slate-500">
+                                <div class="w-full text-center text-sm text-slate-500">
                                     <p>최신 이미지는 업로드 후 새로고침하면 자동으로 반영됩니다.</p>
                                     <a th:href="@{/api/users/{username}/profile-image(username=${user.username})}"
                                        class="mt-2 inline-flex items-center justify-center rounded-full border border-slate-200 px-4 py-2 font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50"
@@ -47,6 +47,46 @@
                                        rel="noopener noreferrer">
                                         원본 이미지 보기
                                     </a>
+                                </div>
+                                <div class="mt-6 w-full space-y-4">
+                                    <div th:if="${success != null}" class="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-left text-sm font-medium text-blue-700 shadow-sm">
+                                        <span th:text="${success}">성공 메시지</span>
+                                    </div>
+                                    <div th:if="${error != null}" class="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-left text-sm font-medium text-rose-700 shadow-sm">
+                                        <span th:text="${error}">에러 메시지</span>
+                                    </div>
+                                    <form method="post"
+                                          th:action="@{/users/me/profile-image}"
+                                          enctype="multipart/form-data"
+                                          class="space-y-4">
+                                        <input th:if="${_csrf != null}"
+                                               th:attr="name=${_csrf.parameterName}, value=${_csrf.token}"
+                                               type="hidden"/>
+                                        <div class="space-y-2 text-left">
+                                            <label for="profileImage" class="text-sm font-semibold text-slate-700">새 프로필 이미지</label>
+                                            <input id="profileImage"
+                                                   name="profileImage"
+                                                   type="file"
+                                                   accept="image/png,image/jpeg,image/gif,image/webp"
+                                                   class="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-300 bg-white px-4 py-3 text-sm text-slate-600 transition focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:ring-offset-0 file:mr-4 file:rounded-full file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 hover:file:bg-slate-700"/>
+                                            <p class="text-xs text-slate-400">PNG, JPG, GIF, WEBP 형식의 최대 2MB 이미지까지 업로드할 수 있습니다.</p>
+                                        </div>
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                                            <button type="submit"
+                                                    class="inline-flex w-full items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/70 focus-visible:ring-offset-2 sm:w-auto">
+                                                이미지 업로드
+                                            </button>
+                                            <button type="submit"
+                                                    name="remove"
+                                                    value="true"
+                                                    th:disabled="${!user.hasProfileImage}"
+                                                    th:attr="aria-disabled=${!user.hasProfileImage}"
+                                                    th:classappend="${!user.hasProfileImage} ? ' cursor-not-allowed opacity-60' : ''"
+                                                    class="inline-flex w-full items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:ring-offset-2 sm:w-auto">
+                                                이미지 삭제
+                                            </button>
+                                        </div>
+                                    </form>
                                 </div>
                             </div>
                         </aside>


### PR DESCRIPTION
## Summary
- add a dedicated form endpoint in the user detail view to handle profile image uploads and removals with flash messaging
- redesign the my page sidebar to include a multipart file form, success/error alerts, and improved accessibility markers
- extend view tests and adjust shared templates/messages so the new workflow is covered and tooltips remain accessible

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dc1266fa14832daafb0e714bb25a96